### PR TITLE
Accounting for Zero 

### DIFF
--- a/src/app/template-engine.ts
+++ b/src/app/template-engine.ts
@@ -81,7 +81,7 @@ export class TemplateEngine {
 
       matches.forEach((rawExpression: string) => {
         const tplExp = new TemplateExpression(rawExpression, rawExpression.slice(2, -2));
-        let resultValue: any = data[tplExp.valueName] || '';
+        let resultValue: any = this.accountForZero(data[tplExp.valueName]);
         if (!data[tplExp.valueName] && this.data[tplExp.valueName]) {
           resultValue = this.data[tplExp.valueName];
         }
@@ -90,6 +90,17 @@ export class TemplateEngine {
       });
       cell.value = cVal;
     });
+  }
+
+  
+  private accountForZero(input: any) {
+    if (input !== null && input !== undefined) {
+      return input;
+    } else if (input === 0){
+        return 0;
+    } else {
+        return null;
+    }
   }
 
   private processValuePipes(cell: Cell, pipes: TemplatePipe[], value: any): string {
@@ -128,7 +139,9 @@ export class TemplateEngine {
       console.error('xlsx-template-ex: Error on process values of pipes', error);
       return 'xlsx-template-ex: Error on process values of pipes. Look for more details in a console.';
     }
-
+    if (value === 0){
+      return value;
+    } 
     return value || '';
   }
 


### PR DESCRIPTION
Quick & Dirty fix to allow for numeric 0 values to pass through! 

In the current build, `0` gets evaluated as falsy, which in turn makes valid `0`s end up as null (blank) in the final/templated document. This is just adding an explicit check for values which === 0. 